### PR TITLE
Fix Error on No Published Questions and Minor Formatting

### DIFF
--- a/list_questions.py
+++ b/list_questions.py
@@ -35,7 +35,7 @@ def display(user):
     for category in curs1.execute('SELECT category FROM Categories;'):
         curs2 = conn.cursor()
         if user != 'moderator':
-            published = 'AND published=True'
+            published = 'AND published'
         else:
             published = ''
         for row in curs2.execute('SELECT email, category, question, id, published FROM QuestionFour WHERE category = ?' + published + ';', category):

--- a/templates/question_view.html
+++ b/templates/question_view.html
@@ -44,7 +44,7 @@
   {% for answer in answers %}
   <div class="block">
   <li>
-    <pre>{{ answer[4] }}</pre>
+    {{ answer[4] }}<br>
     <i>answered by {{ answer[1] }}</i><br>
     <i>on {{ answer[2] }}</i><br>
     {% if user == "moderator" %}


### PR DESCRIPTION
Was throwing error if viewer clicks "View Questions (Viewer)" with no published questions.
The problem was bad SQL
text asking if a boolean column equaled true, when should have just been the column.
Unfortunately, now a page with no questions but the instruction to "click any question
to view it" when it should inform the reader that there are currently no questions
published.

A question that has been answered substantively (i.e., more than just a few words)
did not get wrapped in the div block and ran off the right of the page. Don't know
why the 'pre' tag was used for the question-answer in the first place, but I deleted
that and added a line-break. If there was a specific intent for using the 'pre' tag, 
then reject this pull request (or change it back) and let me know. But in that case,
probably should figure out some other way to get the answer wrapped on the page.